### PR TITLE
Fixes and Expansions to modep-ctrl.py

### DIFF
--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -133,6 +133,23 @@ def bypass_toggle():
 		else:
 			print("Didn't find any stored board")
 
+def board_name_bundle(board_name):
+	# regex to look for boards by short name or full (bundle) path
+	pattern = "/" + board_name + ".pedalboard$" + "|^" + board_name + "$"
+	# pedalboards are saved/returned in unicode, regex needs to be aware
+	regex = re.compile(pattern, re.UNICODE)
+	for bundle in get_pedalboards():
+		if re.search(regex, bundle):
+			return(bundle)
+	return None
+
+def get_board_index_by_bundle(board_bundle):
+	for index, bundle in enumerate(get_pedalboards()):
+		if bundle == board_bundle:
+			return index
+	return None
+
+
 if sys.argv[1] == "next":
 	load_next()
 elif sys.argv[1] == "prev":
@@ -147,11 +164,7 @@ elif sys.argv[1] == "index":
 elif sys.argv[1] == "current":
 	print(get_current_pedalboard())
 elif sys.argv[1] == "load-board":
-	# regex to look for boards by short name or full (bundle) path
-        want_board = "/" + sys.argv[2] + ".pedalboard$" + "|^" + sys.argv[2] + "$"
-	# pedalboards are saved/returned in unicode, regex needs to be aware
-	regex = re.compile(want_board, re.UNICODE)
-        for index, board in enumerate(get_pedalboards()):
-		if re.search(regex, board):
-			print("Switching %s -> %s" % (get_current_pedalboard(),board))
-			load_index(index)
+        bundle = board_name_bundle(sys.argv[2])
+	if bundle:
+		print("Switching %s -> %s" % (get_current_pedalboard(), bundle))
+		load_index(get_board_index_by_bundle(bundle))

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -149,6 +149,17 @@ def get_board_index_by_bundle(board_bundle):
 			return index
 	return None
 
+def load_board_by_name(board_name):
+        bundle = board_name_bundle(board_name)
+	if bundle:
+		print("Switching %s -> %s" % (get_current_pedalboard(), bundle))
+		load_index(get_board_index_by_bundle(bundle))
+	else:
+		print("No board found for %s!" % (board_name))
+
+def list_pedalboards():
+	for pb in get_pedalboards():
+		print pb
 
 if sys.argv[1] == "next":
 	load_next()
@@ -157,14 +168,10 @@ elif sys.argv[1] == "prev":
 elif sys.argv[1] == "bypass":
 	bypass_toggle()
 elif sys.argv[1] == "list":
-	for pb in get_pedalboards():
-		print pb
+	list_pedalboards()
 elif sys.argv[1] == "index":
 	load_index(int(sys.argv[2]))
 elif sys.argv[1] == "current":
 	print(get_current_pedalboard())
 elif sys.argv[1] == "load-board":
-        bundle = board_name_bundle(sys.argv[2])
-	if bundle:
-		print("Switching %s -> %s" % (get_current_pedalboard(), bundle))
-		load_index(get_board_index_by_bundle(bundle))
+	load_board_by_name(sys.argv[2])

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -119,10 +119,10 @@ def load_prev():
 	set_pedalboard(boards[prev])
 
 def load_index(index, load_all):
-	if load_all == False:
-		boards = get_pedalboards(DEFAULT_BANK)
-	else:
+	if load_all == True:
 		boards = get_all_pedalboards()
+	else:
+		boards = get_pedalboards(DEFAULT_BANK)
 
 	if len(boards) == 0:
 		print("No banks or pedalboards!")

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -133,7 +133,6 @@ def load_index(index, load_all):
 		exit(1)
 
 	print("Switching %s -> %s" % (get_current_pedalboard(), boards[index]))
-	#print("Switching to %s" % (boards[index]))
 	set_pedalboard(boards[index])
 
 def bypass_toggle():

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -94,6 +94,7 @@ def get_current_pedalboard_index(pedalboards, current):
 		return -1
 
 def load_next():
+	# get current bank?
 	boards = get_pedalboards(DEFAULT_BANK)
 	if len(boards) == 0:
 		print("No banks or pedalboards!")
@@ -105,6 +106,7 @@ def load_next():
 	set_pedalboard(boards[next])
 
 def load_prev():
+	# get current bank?
 	boards = get_pedalboards(DEFAULT_BANK)
 	if len(boards) == 0:
 		print("No banks or pedalboards!")
@@ -119,7 +121,7 @@ def load_prev():
 	set_pedalboard(boards[prev])
 
 def load_index(index, load_all):
-	if load_all == 0:
+	if load_all == False:
 		boards = get_pedalboards(DEFAULT_BANK)
 	else:
 		boards = get_all_pedalboards()
@@ -170,7 +172,7 @@ def get_board_index_by_bundle(board_bundle):
 def load_board_by_name(board_name):
         bundle = board_name_bundle(board_name)
 	if bundle:
-		load_index(get_board_index_by_bundle(bundle), 1)
+		load_index(get_board_index_by_bundle(bundle), True)
 	else:
 		print("No board found for %s!" % (board_name))
 
@@ -207,7 +209,7 @@ elif sys.argv[1] == "list-banks":
 elif sys.argv[1] == "list-boards":
 	list_all_pedalboards()
 elif sys.argv[1] == "index":
-	load_index(int(sys.argv[2]), 0)
+	load_index(int(sys.argv[2]), False)
 elif sys.argv[1] == "current":
 	print(get_current_pedalboard())
 elif sys.argv[1] == "load-board":

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -146,8 +146,8 @@ elif sys.argv[1] == "index":
 	load_index(int(sys.argv[2]))
 elif sys.argv[1] == "current":
 	print(get_current_pedalboard())
-	#curl localhost:80/pedalboard/current
 elif sys.argv[1] == "load-board":
+	# regex to look for boards by short name or full (bundle) path
         want_board = "/" + sys.argv[2] + ".pedalboard$" + "|^" + sys.argv[2] + "$"
 	# pedalboards are saved/returned in unicode, regex needs to be aware
 	regex = re.compile(want_board, re.UNICODE)

--- a/modep-ctrl.py
+++ b/modep-ctrl.py
@@ -94,7 +94,6 @@ def get_current_pedalboard_index(pedalboards, current):
 		return -1
 
 def load_next():
-	# get current bank?
 	boards = get_pedalboards(DEFAULT_BANK)
 	if len(boards) == 0:
 		print("No banks or pedalboards!")
@@ -106,7 +105,6 @@ def load_next():
 	set_pedalboard(boards[next])
 
 def load_prev():
-	# get current bank?
 	boards = get_pedalboards(DEFAULT_BANK)
 	if len(boards) == 0:
 		print("No banks or pedalboards!")


### PR DESCRIPTION
I added a number of new definitions to the modep-ctrl.py, because when I started trying to use it to change pedalboards, I noticed some problems, and things that could be easily improved.

The first thing I noticed, was it seemed that only some built in pedalboards were returned by the "list" command, which was getting it's info from calling 'get_pedalboards'.

```bash
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py list
/usr/local/modep/.pedalboards/DISTORTION.pedalboard
/usr/local/modep/.pedalboards/ORGANS.pedalboard
/usr/local/modep/.pedalboards/SEQUENCED_DRUMS.pedalboard
/usr/local/modep/.pedalboards/default.pedalboard
modep@modep:~/modep-btn-scripts $ 
```

I looked in to it, and I'm not sure why get_pedalboards was previously referencing "/banks", but it seemed not right to me. After some cross referencing in https://github.com/BlokasLabs/mod-ui/blob/master/mod/webserver.py , it seemed that it was more proper to look at "pedalboard/list" here.
So therefore, I rewrote get_pedalboards to look at the pedalboards/list instead of /banks.
I needed to adjust a number of other calls accordingly.

Also, seeing some possibly useful and not implemented definitions inside, I added a 'current' option to the main case statement at the end, to simply return the currently used pedalboard:

```bash
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py current
/usr/local/modep/.pedalboards/DEFAULT.pedalboard
modep@modep:~/modep-btn-scripts $ 
```

The last bit is the biggest thing I was after. I also added a few definitions to make it easier to select pedalboards by their saved names, which works with the short name, full(bundle) name, and return errors as appropriate:

```bash
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py list
/usr/local/modep/.pedalboards/DEFAULT.pedalboard
/usr/local/modep/.pedalboards/DISTORTION.pedalboard
/usr/local/modep/.pedalboards/GUITAR_PB1.pedalboard
/usr/local/modep/.pedalboards/GUITAR_PB1_NOMID-74428.pedalboard
/usr/local/modep/.pedalboards/GUITAR_PB1_NOMID.pedalboard
/usr/local/modep/.pedalboards/HEXA_SYNTHS.pedalboard
/usr/local/modep/.pedalboards/ORGANS.pedalboard
/usr/local/modep/.pedalboards/SEQUENCED_DRUMS.pedalboard
/usr/local/modep/.pedalboards/default.pedalboard
/usr/local/modep/.pedalboards/figgis.pedalboard
/usr/local/modep/.pedalboards/shutdown_button.pedalboard
modep@modep:~/modep-btn-scripts $ 
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py load-board HEXA_SYNTHS
Switching /usr/local/modep/.pedalboards/DEFAULT.pedalboard -> /usr/local/modep/.pedalboards/HEXA_SYNTHS.pedalboard
modep@modep:~/modep-btn-scripts $ 
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py load-board pizza
No board found for pizza!
modep@modep:~/modep-btn-scripts $ 
modep@modep:~/modep-btn-scripts $ ./modep-ctrl.py load-board /usr/local/modep/.pedalboards/DEFAULT.pedalboard
Switching /usr/local/modep/.pedalboards/HEXA_SYNTHS.pedalboard -> /usr/local/modep/.pedalboards/DEFAULT.pedalboard
modep@modep:~/modep-btn-scripts $ 
```

Let me know if there are any troubles with these changes?